### PR TITLE
Nissix plugin scope-packages on @wix/renovate-test-app-team

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   },
   "devDependencies": {
-    "yoshi": "^3.0.0"
+    "@wix/yoshi": "^3.0.0"
   },
   "dependencies": {
     "wix-santa": "1.7585.0"

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,5 +1,5 @@
 module.exports = function(wallaby) {
-  return Object.assign({}, require('yoshi/config/wallaby-jest')(wallaby), {
+  return Object.assign({}, require('@wix/yoshi/config/wallaby-jest')(wallaby), {
     // set to undefined to let Wallaby decide the number of processes based on the system's capacity
     workers: undefined,
   });


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.241s
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
error Couldn't find any versions for "wix-santa" that matches "1.7585.0"
(node:4818) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 1: yarn
    at makeError (/app/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/app/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:4818) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:4818) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.



Output Log:
Migrating package "@wix/renovate-test-app-team" in .


## Migration from non scope to @wix/scoped packages
> /tmp/71de54c5b2a03dd1eb44aa97bb5987f9

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
```
yarn install v1.22.5
[1/4] Resolving packages...
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

